### PR TITLE
Assign zero only to existing destination values

### DIFF
--- a/model.go
+++ b/model.go
@@ -602,6 +602,14 @@ func doCopy(dv, sv reflect.Value) []error {
 		// get dst field by name
 		dfv := dv.FieldByName(f.Name)
 
+		// validate field - exists in dst, kind and type
+		err := valiadateCopyField(f, sfv, dfv)
+
+		if err != nil {
+			errs = append(errs, err)
+
+			continue
+		}
 		// if value is not exists
 		if !isVal {
 			// field value is zero and check 'omitempty' option present
@@ -610,14 +618,6 @@ func doCopy(dv, sv reflect.Value) []error {
 			if !tag.isOmitEmpty() {
 				dfv.Set(zeroOf(dfv))
 			}
-
-			continue
-		}
-
-		// validate field - exists in dst, kind and type
-		err := valiadateCopyField(f, sfv, dfv)
-		if err != nil {
-			errs = append(errs, err)
 
 			continue
 		}

--- a/model_test.go
+++ b/model_test.go
@@ -1902,6 +1902,29 @@ func TestKind(t *testing.T) {
 	assertEqual(t, true, reflect.Invalid == kind6)
 }
 
+func TestMissingDestField(t *testing.T) {
+
+	type C struct {
+	}
+
+	type A struct {
+		X string
+		Y string
+		Z C
+	}
+
+	type B struct {
+		X string
+	}
+
+	a := A{X: "X", Y: "Y", Z: C{}}
+	b := B{}
+	errs := Copy(&b, &a)
+	assertEqual(t, 2, len(errs))
+	assertEqual(t, "Field: 'Y', does not exists in dst", errs[0].Error())
+	assertEqual(t, "Field: 'Z', does not exists in dst", errs[1].Error())
+}
+
 //
 // helper test methods
 //


### PR DESCRIPTION
The destination field is now validated before the zero value is assigned
to it. This way, we are not assigning a zero value to a non existing
field.